### PR TITLE
Script for bulk seeding debates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,8 +5,5 @@
 *.cleanedup.*
 *.original.*
 data
-results
 .env
-chromedriver
-*.sh
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 .venv
 .ipynb_checkpoints
 *.output.csv

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.venv
+.ipynb_checkpoints
+*.output.csv
+*.cleanedup.*
+*.original.*
+data
+results
+.env
+chromedriver
+*.sh
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ python -m venv .venv --system-site-packages
 
 in the root folder. This lets you install additional Python packages without interfering with the main Anaconda installation.
 
+You may need to select the local `.venv` interpreter in your IDE at this point to run the virtual environment Python install.
+
 Once this is done, run
 
 ```

--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
-# scripts
-Code to operate on polis — some of these scripts will become features later
+# pol.is Scripts
+
+Scripts to streamline the running of the pol.is instance used in Policy Lab. Some of these will become features later on.
+
+## Getting Started
+
+Most scripts require [Anaconda Python environment](https://www.anaconda.com/) to be installed. Once installed, setup a virtual environment using
+
+```
+python -m venv .venv --system-site-packages
+```
+
+in the root folder. This lets you install additional Python packages without interfering with the main Anaconda installation.
+
+Once this is done, run
+
+```
+pip install -r requirements.txt
+```
+
+We also don't want to include output of the notebooks in Git for GDPR reasons. To avoid this run 
+
+```
+git config filter.strip-notebook-output.clean 'jupyter nbconvert --ClearOutputPreprocessor.enabled=True --to=notebook --stdin --stdout --log-level=ERROR'
+```
+
+Individual script folders will contain further instructions particular to that script.
+
+## Conventions
+
+* To avoid checking PII or secrets into Git ...
+  * Use a `.env` file for secrets
+  * Use `data` folder for input files
+  * Name output files `<something>.output.csv`
+* Sometimes you may want to manually clean up data so that teh script can read it. Rename the original input file with `<filename>.original.<extension>` and create a copy called `<filename>.cleanedup.<extension>` for the file containing edits. Both will be ignored by Git.
+* If you need a new library installing, add it to the root `requirements.txt`
+
+There are some common environment variables used in the scripts
+| Name | Description |
+| --- | --- |
+| `CONVERSATION_ID` | The characters after the slash on the conversation page e.g. `9rak4kaysm` |
+| `DRY_RUN` | Set to `true` for the script to execute but not make any changes so you can check the output |
+| `POLIS_USERNAME` | The username for an account that owns the particular debate |
+| `POLIS_PASSWORD` | The password for an account that owns the particular debate |
+| `POLIS_API_BASE_URL` | The URL for the pol.is API without trailing slash e.g. `https://pol.is/api/v3` |

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+python-dotenv==0.20.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-python-dotenv==0.20.0
+python-dotenv==0.21.0

--- a/seed-debate/.gitignore
+++ b/seed-debate/.gitignore
@@ -1,0 +1,1 @@
+new-comments.csv

--- a/seed-debate/.template.env
+++ b/seed-debate/.template.env
@@ -1,0 +1,6 @@
+DRY_RUN=true
+CONVERSATION_ID=
+POLIS_USERNAME=
+POLIS_PASSWORD=
+COMMENT_FILENAME='./new-comments.cleanedup.csv'
+POLIS_API_BASE_URL=pol.is/api/v3

--- a/seed-debate/README.md
+++ b/seed-debate/README.md
@@ -1,0 +1,17 @@
+# seed-debate
+
+Adds a list of comments in a CSV file to the debate. Saves having to do this one-by-one in the UI.
+
+## Instructions
+
+* Setup your evironment according to the [root README](../README.md)
+* Create a CSV file that has at least the following column
+
+| `new-comments` |
+| --- |
+| _A statement_ |
+| _Another statement_ |
+| _..._ |
+
+* Copy `.template.env` to `.env` and fill in the relevant details
+* Run `python run.py`

--- a/seed-debate/run.py
+++ b/seed-debate/run.py
@@ -1,0 +1,77 @@
+import pandas as pd
+from dotenv import load_dotenv
+import requests
+import os
+import sys
+
+load_dotenv('./.env')
+
+CONVERSATION_ID = os.getenv('CONVERSATION_ID')
+POLIS_USERNAME = os.getenv('POLIS_USERNAME')
+POLIS_PASSWORD = os.getenv('POLIS_PASSWORD')
+COMMENT_FILENAME = os.getenv('COMMENT_FILENAME')
+POLIS_API_BASE_URL = os.getenv('POLIS_API_BASE_URL')
+# Err on the side of performing a dry run
+DRY_RUN = True if os.getenv('DRY_RUN').lower() != 'false' else False
+
+
+def check():
+    print(f'''
+    Dry run: {DRY_RUN}
+    Debate: {CONVERSATION_ID}
+    Account: {POLIS_USERNAME}
+    Polis API URL: {POLIS_API_BASE_URL}
+    File: {COMMENT_FILENAME}
+    ''')
+
+    input("Is this ok? [Enter to continue]")
+    print('')
+
+
+def report(comment_id, result, statement):
+    '''Standardise reporting'''
+    try:
+        comment_id_str = str(int(comment_id))
+    except (ValueError, TypeError):
+        comment_id_str = 'NaN'
+    print(f"{comment_id_str}|{result}|{statement}")
+
+
+def login(session):
+    '''Logs into pol.is'''
+    res = session.post(POLIS_API_BASE_URL + '/auth/login', json={
+        'email': POLIS_USERNAME, 'password': POLIS_PASSWORD})
+    if res.status_code != 200:
+        print('Failed to login - quitting')
+        sys.exit()
+
+
+def main():
+    '''The main script'''
+    print(f'Reading {COMMENT_FILENAME} ...')
+
+    new_statements = pd.read_csv(COMMENT_FILENAME)['new-comments']
+
+    session = requests.Session()
+
+    print('Getting a sign-in token ...')
+    login(session)
+
+    for statement in new_statements:
+        comment_id = None
+        result = 'Added'
+        if not DRY_RUN:
+            res = session.post(POLIS_API_BASE_URL + '/comments', json={
+                'txt': statement, 'pid': 'mypid', 'conversation_id': CONVERSATION_ID, 'is_seed': 'true'})
+            comment_id = res.json()['tid']
+            if res.status_code != 200:
+                result = f'Failed with status {res.status_code}'
+        report(comment_id, result, statement)
+
+    print('')
+    print('Done')
+
+
+if __name__ == '__main__':
+    check()
+    main()


### PR DESCRIPTION
  > Note that the `seed-debate` script is used extensively for our own instance but triggered a block on Cloudflare when using against pol.is. Executing via Postman works fine. I'm not sure if this can be mitigated - possibly by pretending to be Postman?


* Includes a set of conventions for writing scripts - happy to discuss these
* A script for bulk uploading seed statements to a live debate